### PR TITLE
Fix DatePicker crash on iPad

### DIFF
--- a/ios/DatePickerModule.swift
+++ b/ios/DatePickerModule.swift
@@ -65,28 +65,29 @@ public class DatePickerModule: Module {
                 datePicker.preferredDatePickerStyle = .wheels
             }
 
-          
+
           let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
           self.alertController = alert;
-          
+
           alert.view.addSubview(datePicker)
 
-          
+
           // make height equal to date picker and adjust for Ok and Cancel buttons
           let heightConstraint = NSLayoutConstraint(item: alert.view as Any, attribute: .height, relatedBy: .equal, toItem: datePicker, attribute: .height, multiplier: 1, constant:  2 * 80)
           alert.view.addConstraint(heightConstraint)
 
+          let widthConstraint = NSLayoutConstraint(item: alert.view as Any, attribute: .width, relatedBy: .equal, toItem: datePicker, attribute: .width, multiplier: 1, constant: 32)
+          alert.view.addConstraint(widthConstraint)
+
           // Adds some padding top to date picker
-          datePicker.bounds = datePicker.frame.insetBy(dx: 0.0, dy: -32.0);
+          datePicker.bounds = datePicker.frame
 
 
-          
           // Horizontally center date picker
           datePicker.translatesAutoresizingMaskIntoConstraints = false
           NSLayoutConstraint.activate([
             datePicker.centerXAnchor.constraint(equalTo: alert.view.centerXAnchor),
           ])
-        
 
           // Add an action to the alert controller that will trigger when the user selects a date
           let okAction = UIAlertAction(title: "OK", style: .default) { _ in
@@ -107,14 +108,19 @@ public class DatePickerModule: Module {
           alert.addAction(okAction)
           alert.addAction(cancelAction)
 
-         
 
+         
           let alertWindow = UIWindow(frame: UIScreen.main.bounds)
           alertWindow.rootViewController = UIViewController()
           alertWindow.windowLevel = UIWindow.Level.alert + 1;
           alertWindow.makeKeyAndVisible()
-          alertWindow.rootViewController?.present(alert, animated: true)
+
+          alert.popoverPresentationController?.sourceView = alertWindow
+          alert.popoverPresentationController?.sourceRect = CGRect(x: alertWindow.bounds.midX, y: alertWindow.bounds.midY, width: 0, height: 0)
+          alert.popoverPresentationController?.permittedArrowDirections = []
           
+          alertWindow.rootViewController?.present(alert, animated: true)
+
           self.alertWindow = alertWindow;
 
       }.runOnQueue(.main)

--- a/ios/DatePickerModule.swift
+++ b/ios/DatePickerModule.swift
@@ -65,13 +65,13 @@ public class DatePickerModule: Module {
                 datePicker.preferredDatePickerStyle = .wheels
             }
 
-
+          
           let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
           self.alertController = alert;
-
+          
           alert.view.addSubview(datePicker)
 
-
+          
           // make height equal to date picker and adjust for Ok and Cancel buttons
           let heightConstraint = NSLayoutConstraint(item: alert.view as Any, attribute: .height, relatedBy: .equal, toItem: datePicker, attribute: .height, multiplier: 1, constant:  2 * 80)
           alert.view.addConstraint(heightConstraint)
@@ -80,14 +80,16 @@ public class DatePickerModule: Module {
           alert.view.addConstraint(widthConstraint)
 
           // Adds some padding top to date picker
-          datePicker.bounds = datePicker.frame
+          datePicker.bounds = datePicker.frame.insetBy(dx: 0.0, dy: -32.0);
 
 
+          
           // Horizontally center date picker
           datePicker.translatesAutoresizingMaskIntoConstraints = false
           NSLayoutConstraint.activate([
             datePicker.centerXAnchor.constraint(equalTo: alert.view.centerXAnchor),
           ])
+        
 
           // Add an action to the alert controller that will trigger when the user selects a date
           let okAction = UIAlertAction(title: "OK", style: .default) { _ in
@@ -108,19 +110,19 @@ public class DatePickerModule: Module {
           alert.addAction(okAction)
           alert.addAction(cancelAction)
 
-
          
+
           let alertWindow = UIWindow(frame: UIScreen.main.bounds)
           alertWindow.rootViewController = UIViewController()
           alertWindow.windowLevel = UIWindow.Level.alert + 1;
           alertWindow.makeKeyAndVisible()
-
+          
           alert.popoverPresentationController?.sourceView = alertWindow
           alert.popoverPresentationController?.sourceRect = CGRect(x: alertWindow.bounds.midX, y: alertWindow.bounds.midY, width: 0, height: 0)
           alert.popoverPresentationController?.permittedArrowDirections = []
-          
-          alertWindow.rootViewController?.present(alert, animated: true)
 
+          alertWindow.rootViewController?.present(alert, animated: true)
+          
           self.alertWindow = alertWindow;
 
       }.runOnQueue(.main)


### PR DESCRIPTION
I noticed the following error while using the universal design system you've built and trying to open the date picker on iPad:

```
Your application has presented a UIAlertController (<UIAlertController: 0x7fa4e56dda00>) of style
UIAlertControllerStyleActionSheet from UIViewController (<UIViewController: 0x7fa500c59390>). The 
modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location 
information for this popover through the alert controller's popoverPresentationController. You must provide either a 
sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you
may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.
```

This PR is an attempt to fix it.
Disclaimer: my knowledge of iOS is very limited.

### How to reproduce:

- Open the "iPad (10th generation)" Simulator
- Load the master branch of this project
- `yarn; cd example; rm -rf ios; yarn ios`
- Wait for the example app to load on the iPad sim
- Click on the "Open picker" button, you should see the error in the console

### Testing Instructions

- Apply this patch
- `yarn ios`
- Check that the error is gone and that the date picker looks decent on iPad

<img src="https://user-images.githubusercontent.com/230230/217387459-1e264d24-16a8-4168-83d4-a32dd35a2927.png" width="50%" height="50%">
